### PR TITLE
Treat all string types as strings.

### DIFF
--- a/include/stringify/stringify.hpp
+++ b/include/stringify/stringify.hpp
@@ -87,10 +87,8 @@ namespace
     template<> struct is_str<wchar_t*> : std::true_type {};
     template<> struct is_str<const char*> : std::true_type {};
     template<> struct is_str<const wchar_t*> : std::true_type {};
-    template<> struct is_str<std::string> : std::true_type {};
-    template<> struct is_str<const std::string> : std::true_type {};
-    template<> struct is_str<std::wstring> : std::true_type {};
-    template<> struct is_str<const std::wstring> : std::true_type {};
+    template<typename C, typename T, typename A>
+    struct is_str<std::basic_string<C, T, A>> : std::true_type {};
 
     // char type traits
     template<class T> struct is_char : std::false_type {};


### PR DESCRIPTION
This adds support for any basic string, so this may work with more use cases of strings, like custom allocators and such.